### PR TITLE
Automatic example generation

### DIFF
--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -23,8 +23,8 @@ jobs:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v3
       
-      - name: install ps2pdf
-        run: sudo apt install ps2pdf
+      - name: install ghostscript
+        run: sudo apt install ghostscript
 
       - name: generate postscript
         run: src/generate.rb example.md > output.ps

--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -25,8 +25,11 @@ jobs:
 
       - run: |
           src/generate.rb example.md > output.ps
+          ps2pdf output.ps
           
       - uses: actions/upload-artifact@v3
         with:
           name: example-output
-          path: output.ps
+          path: |
+            output.ps
+            output.pdf

--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -22,10 +22,15 @@ jobs:
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v3
+      
+      - name: install ps2pdf
+        run: sudo apt install ps2pdf
 
-      - run: |
-          src/generate.rb example.md > output.ps
-          ps2pdf output.ps
+      - name: generate postscript
+        run: src/generate.rb example.md > output.ps
+      
+      - name: generate pdf
+        run: ps2pdf output.ps
           
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -1,0 +1,32 @@
+# This is a basic workflow to help you get started with Actions
+
+name: Generate Example
+
+# Controls when the workflow will run
+on:
+  # Triggers the workflow on push or pull request events but only for the "master" branch
+  push:
+    branches: [ "master" ]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v3
+
+      - run: |
+          src/generate.rb example.md > output.ps
+          
+      - uses: actions/upload-artifact@v3
+        with:
+          name: example-output
+          path: output.ps


### PR DESCRIPTION
Github actions will automatically run `generate.rb` on `example.md` for every push to main, and it will be stored as an artifact in the **Actions** tab. idk if this is useful?