### PR TITLE
Change Block Comments to Single Line Comments

### DIFF
--- a/src/generate.rb
+++ b/src/generate.rb
@@ -1,29 +1,28 @@
 #!/usr/bin/ruby
 
-=begin
+#
+#     Copyright 2022 Jacob Bates
+#
+#     Licensed under the Apache License, Version 2.0 (the "License");
+#     you may not use this file except in compliance with the License.
+#     You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#     Unless required by applicable law or agreed to in writing, software
+#     distributed under the License is distributed on an "AS IS" BASIS,
+#     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#     See the License for the specific language governing permissions and
+#     limitations under the License.
+#
 
-    Copyright 2022 Jacob Bates
 
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
+# TODO: - Sorta-Tables (tab a line, do part of a line in left-align and part in right)
 
-        http://www.apache.org/licenses/LICENSE-2.0
-
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
-
-=end
-
-# TODO - Sorta-Tables (tab a line, do part of a line in left-align and part in right)
-
-# TODO - PDF Output
+# TODO: - PDF Output
 # TODO - Write Stylesheets
 
-# TODO - Testing/Debugging (escape sequences in source, things missing from stylesheet, invalid input)
+# TODO: - Testing/Debugging (escape sequences in source, things missing from stylesheet, invalid input)
 
 # Other Classes
 require_relative "stylesheet.rb"

--- a/src/macros.rb
+++ b/src/macros.rb
@@ -1,36 +1,32 @@
-=begin
-
-    Copyright 2022 Jacob Bates
-
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
-
-        http://www.apache.org/licenses/LICENSE-2.0
-
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
-
-=end
-
+#
+#     Copyright 2022 Jacob Bates
+#
+#     Licensed under the Apache License, Version 2.0 (the "License");
+#     you may not use this file except in compliance with the License.
+#     You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#     Unless required by applicable law or agreed to in writing, software
+#     distributed under the License is distributed on an "AS IS" BASIS,
+#     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#     See the License for the specific language governing permissions and
+#     limitations under the License.
+#
 class Macros
+  # Macros
+  @@macros = {}
 
-    # Macros
-    @@macros = {}
+  # Add Macro
+  def self.add(key, string)
+    return unless key.match?(/^[a-z0-9-]+$/) || key == '_begin' || key == '_end'
 
-    # Add Macro
-    def Macros.add(key, string)
-        unless key.match?(/^[a-z0-9-]+$/) || key == "_begin" || key == "_end" then return end
-        @@macros[key] = string
-    end
+    @@macros[key] = string
+  end
 
-    # Get Macro
-    def Macros.get(key)
-        m = @@macros[key]
-        return m.nil? ? "" : m
-    end
-
+  # Get Macro
+  def self.get(key)
+    m = @@macros[key]
+    m.nil? ? '' : m
+  end
 end

--- a/src/page_setup.rb
+++ b/src/page_setup.rb
@@ -1,20 +1,19 @@
-=begin
+#
+#     Copyright 2022 Jacob Bates
+#
+#     Licensed under the Apache License, Version 2.0 (the "License");
+#     you may not use this file except in compliance with the License.
+#     You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#     Unless required by applicable law or agreed to in writing, software
+#     distributed under the License is distributed on an "AS IS" BASIS,
+#     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#     See the License for the specific language governing permissions and
+#     limitations under the License.
+#
 
-    Copyright 2022 Jacob Bates
-
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
-
-        http://www.apache.org/licenses/LICENSE-2.0
-
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
-
-=end
 
 require_relative "stylesheet.rb"
 require_relative "macros.rb"

--- a/src/stylesheet.rb
+++ b/src/stylesheet.rb
@@ -1,20 +1,19 @@
-=begin
+#
+#     Copyright 2022 Jacob Bates
+#
+#     Licensed under the Apache License, Version 2.0 (the "License");
+#     you may not use this file except in compliance with the License.
+#     You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#     Unless required by applicable law or agreed to in writing, software
+#     distributed under the License is distributed on an "AS IS" BASIS,
+#     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#     See the License for the specific language governing permissions and
+#     limitations under the License.
+#
 
-    Copyright 2022 Jacob Bates
-
-    Licensed under the Apache License, Version 2.0 (the "License");
-    you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
-
-        http://www.apache.org/licenses/LICENSE-2.0
-
-    Unless required by applicable law or agreed to in writing, software
-    distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-    limitations under the License.
-
-=end
 
 require "json"
 


### PR DESCRIPTION
Single-line comments are easier to read; each individual line of code can be more easily analyzed in a vacuum or without an editor changing the font/color.

Block comments are more useful for quickly disabling large swaths of code for debugging instead of documentation.